### PR TITLE
Out of office notification per department

### DIFF
--- a/ZohoApp.ts
+++ b/ZohoApp.ts
@@ -21,7 +21,7 @@ import { ZohoCommand } from './commands/ZohoCommand';
 import { BirthdayEndpoint } from './endpoints/Birthday';
 import { AnniversaryEndpoint } from './endpoints/Anniversary';
 import { WhosOutEndpoint } from './endpoints/WhosOut';
-import { AppSetting, settings } from './settings';
+import { AppSetting, settings } from './settings/settings';
 import { PeopleCache } from './lib/PeopleCache';
 
 export class ZohoApp extends App {
@@ -71,6 +71,11 @@ export class ZohoApp extends App {
      */
     public readonly peopleCache: PeopleCache;
 
+    /**
+     * Each department should have a default room
+     */
+    public readonly departmentRooms: Map<string, IRoom> = new Map<string, IRoom>();
+
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
         this.zohoPeople = new ZohoPeople(this);
@@ -89,6 +94,18 @@ export class ZohoApp extends App {
      */
     public async onEnable(environmentRead: IEnvironmentRead, configModify: IConfigurationModify): Promise<boolean> {
         this.zohoRoomId = await environmentRead.getSettings().getValueById(AppSetting.ZohoRoom);
+        try {
+            const departmentRoomsObject: Record<string, IRoom['id']> = JSON.parse(await environmentRead.getSettings().getValueById(AppSetting.DepartmentRoomsJson));
+            Object.entries(departmentRoomsObject).forEach(async ([department, roomId]) => {
+                const room = await this.getAccessors().reader.getRoomReader().getById(roomId);
+                if (room) {
+                    this.departmentRooms.set(department, room);
+                }
+            })
+        } catch (err) {
+            this.getLogger().warn('invalid value for setting', AppSetting.DepartmentRoomsJson);
+            this.getLogger().warn('out notifications will only be sent to the main Zoho Room');
+        }
         if (this.zohoRoomId) {
             this.zohoRoom = await this.getAccessors().reader.getRoomReader().getById(this.zohoRoomId) as IRoom;
         } else {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,5 +14,7 @@
     "zoho_room": "Zoho Room",
     "zoho_room_description": "Where to post Zoho messages",
     "holiday_countries": "Holiday Countries",
-    "holiday_countries_description": "List of countries to fetch holidays from"
+    "holiday_countries_description": "List of countries to fetch holidays from",
+    "department_rooms_json": "Department Rooms",
+    "department_rooms_json_description": "Ids of each department's room as a map from deparment name to roomId in JSON"
 }

--- a/lib/ZohoPeople.ts
+++ b/lib/ZohoPeople.ts
@@ -1,6 +1,6 @@
 import { IHttpRequest, IHttpResponse, RequestMethod } from "@rocket.chat/apps-engine/definition/accessors";
 import { IApp } from "@rocket.chat/apps-engine/definition/IApp";
-import { AppSetting } from "../settings";
+import { AppSetting } from "../settings/settings";
 
 export class ZohoPeople {
     private token: string = '';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,14 +1,14 @@
 import { IModify, IRead } from '@rocket.chat/apps-engine/definition/accessors';
 import { IRoom, RoomType } from '@rocket.chat/apps-engine/definition/rooms';
 
-import { ZohoApp } from './ZohoApp';
+import { ZohoApp } from '../ZohoApp';
 
 export function formatDate(date: Date): string {
-    return `${ date.getFullYear() }-${ (date.getMonth() < 9 ? '0' : '') + (date.getMonth() + 1) }-${ (date.getDate() < 10 ? '0' : '') + date.getDate() }`;
+    return `${date.getFullYear()}-${(date.getMonth() < 9 ? '0' : '') + (date.getMonth() + 1)}-${(date.getDate() < 10 ? '0' : '') + date.getDate()}`;
 }
 
 export function getMonthAndDay(date: Date): string {
-    return `${ (date.getMonth() < 9 ? '0' : '') + (date.getMonth() + 1) }-${ (date.getDate() < 10 ? '0' : '') + date.getDate() }`;
+    return `${(date.getMonth() < 9 ? '0' : '') + (date.getMonth() + 1)}-${(date.getDate() < 10 ? '0' : '') + date.getDate()}`;
 }
 
 export function isDateBetween(date: Date, from: Date, to?: Date): boolean {

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -5,6 +5,7 @@ export enum AppSetting {
     PeopleSecret = 'people_secret',
     PeopleRefreshToken = 'people_refresh_token',
     ZohoRoom = 'zoho_room',
+    DepartmentRoomsJson = 'department_rooms_json'
 }
 
 export const settings: Array<ISetting> = [
@@ -14,8 +15,8 @@ export const settings: Array<ISetting> = [
         packageValue: '',
         required: true,
         public: true,
-        i18nLabel: 'people_client_id',
-        i18nDescription: 'people_client_id_description',
+        i18nLabel: AppSetting.PeopleClientId,
+        i18nDescription: `${AppSetting.PeopleClientId}_description`,
     },
     {
         id: AppSetting.PeopleSecret,
@@ -23,8 +24,8 @@ export const settings: Array<ISetting> = [
         packageValue: '',
         required: true,
         public: true,
-        i18nLabel: 'people_secret',
-        i18nDescription: 'people_secret_description',
+        i18nLabel: AppSetting.PeopleSecret,
+        i18nDescription: `${AppSetting.PeopleSecret}_description`,
     },
     {
         id: AppSetting.PeopleRefreshToken,
@@ -32,8 +33,8 @@ export const settings: Array<ISetting> = [
         packageValue: '',
         required: true,
         public: true,
-        i18nLabel: 'people_refresh_token',
-        i18nDescription: 'people_refresh_token_description',
+        i18nLabel: AppSetting.PeopleRefreshToken,
+        i18nDescription: `${AppSetting.PeopleRefreshToken}_description`,
     },
     {
         id: AppSetting.ZohoRoom,
@@ -41,7 +42,16 @@ export const settings: Array<ISetting> = [
         packageValue: '',
         required: true,
         public: true,
-        i18nLabel: 'zoho_room',
-        i18nDescription: 'zoho_room_description',
+        i18nLabel: AppSetting.ZohoRoom,
+        i18nDescription: `${AppSetting.ZohoRoom}_description`,
+    },
+    {
+        id: AppSetting.DepartmentRoomsJson,
+        type: SettingType.STRING,
+        packageValue: '',
+        required: false,
+        public: true,
+        i18nLabel: AppSetting.DepartmentRoomsJson,
+        i18nDescription: `${AppSetting.DepartmentRoomsJson}_description`,
     },
 ];


### PR DESCRIPTION
The new setting will accept a JSON string like
```json
{
    "Engineering": "rocket-chat-engineering-master-class",
    "Marketing and Community": "marketing-and-community",
}
```
I chose JSON because our app settings is not very flexible, departments may increase or the _name_ might change, and a dedicated field for each department thus didn't make sense. I also don't know all the departments, so it wasn't possible for me either. 

Secondly, I couldn't test this 🥲